### PR TITLE
FIX: Ensure default exports for route modules and correct authMiddlew…

### DIFF
--- a/synchat-ai-backend/src/routes/inboxRoutes.js
+++ b/synchat-ai-backend/src/routes/inboxRoutes.js
@@ -1,7 +1,8 @@
-const express = require('express');
+import express from 'express';
+import { protectRoute as authMiddleware } from '../middleware/authMiddleware.js';
+import * as inboxController from '../controllers/inboxController.js'; // inboxController uses named exports
+
 const router = express.Router();
-const authMiddleware = require('../middleware/authMiddleware');
-const inboxController = require('../controllers/inboxController'); // Controller to be created later
 
 // Route to list conversations
 router.get('/conversations', authMiddleware, inboxController.listConversations);
@@ -15,4 +16,4 @@ router.post('/conversations/:conversation_id/messages', authMiddleware, inboxCon
 // Route to change the status of a conversation
 router.put('/conversations/:conversation_id/status', authMiddleware, inboxController.changeConversationStatus);
 
-module.exports = router;
+export default router;

--- a/synchat-ai-backend/src/routes/knowledgeManagementRoutes.js
+++ b/synchat-ai-backend/src/routes/knowledgeManagementRoutes.js
@@ -1,7 +1,8 @@
-const express = require('express');
+import express from 'express';
+import { protectRoute as authMiddleware } from '../middleware/authMiddleware.js';
+import * as knowledgeManagementController from '../controllers/knowledgeManagementController.js';
+
 const router = express.Router();
-const authMiddleware = require('../middleware/authMiddleware');
-const knowledgeManagementController = require('../controllers/knowledgeManagementController');
 
 // Route to upload a file
 router.post('/upload', authMiddleware, knowledgeManagementController.uploadFile);
@@ -15,4 +16,4 @@ router.post('/sources/:source_id/ingest', authMiddleware, knowledgeManagementCon
 // Route to delete a specific source
 router.delete('/sources/:source_id', authMiddleware, knowledgeManagementController.deleteSource);
 
-module.exports = router;
+export default router;


### PR DESCRIPTION
…are import

- I modified `synchat-ai-backend/src/routes/inboxRoutes.js` to correctly import `protectRoute` as a named import from `authMiddleware.js` (aliased as `authMiddleware`).
- I converted `synchat-ai-backend/src/routes/knowledgeManagementRoutes.js` from CommonJS to ES Modules. This includes:
    - Changing `require` to `import` statements.
    - Ensuring correct import of `protectRoute` (named, aliased) from `authMiddleware.js`.
    - Ensuring correct import of `knowledgeManagementController.js` (using `import * as ...`).
    - Changing `module.exports = router;` to `export default router;`.

These changes address the `SyntaxError` related to missing default exports in route modules when imported by `server.js` and ensure consistency in how route modules are structured and how `authMiddleware` is imported.