### PR TITLE
FIX: Add multer to backend dependencies

### DIFF
--- a/synchat-ai-backend/package.json
+++ b/synchat-ai-backend/package.json
@@ -20,6 +20,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^4.19.2",
+    "multer": "^1.4.5-lts.1",
     "openai": "^4.95.0",
     "pdf-parse": "^1.1.1",
     "stripe": "^15.8.0"


### PR DESCRIPTION
The package 'multer' was missing from the dependencies in `synchat-ai-backend/package.json`, causing an `ERR_MODULE_NOT_FOUND` error in the Vercel runtime environment.

This commit adds `multer` (version ^1.4.5-lts.1) to the `dependencies` section to ensure it gets installed during deployment.