### PR TITLE
Fix: Correct vercel.json configuration for function settings

### DIFF
--- a/synchat-ai-backend/vercel.json
+++ b/synchat-ai-backend/vercel.json
@@ -3,19 +3,17 @@
   "builds": [
     {
       "src": "server.js",
-      "use": "@vercel/node"
+      "use": "@vercel/node",
+      "config": {
+        "maxDuration": 30,
+        "memory": 1600
+      }
     }
   ],
   "routes": [
     {
-      "src": "/(.*)", 
+      "src": "/(.*)",
       "dest": "server.js"
     }
-  ],
-  "functions": {
-    "server.js": {
-      "maxDuration": 30,
-      "memory": 1600
-    }
-  }
+  ]
 }


### PR DESCRIPTION
Updates `vercel.json` to place the `maxDuration` and `memory` configurations within the `config` object of the relevant entry in the `builds` array. This resolves the Vercel deployment error: "The `functions` property cannot be used in conjunction with the `builds` property."

The 'server.js' function is now configured with:
- memory: 1600MB
- maxDuration: 30s

This is part of the effort to resolve Puppeteer deployment issues on Vercel.