### PR TITLE
Refactor: Move client creation from trigger to backend API

### DIFF
--- a/synchat-ai-backend/server.js
+++ b/synchat-ai-backend/server.js
@@ -10,6 +10,7 @@ import inboxRoutes from './src/routes/inboxRoutes.js'; // Shared Inbox routes
 import paymentRoutes from './src/routes/paymentRoutes.js'; // Payment routes
 import publicChatRoutes from './src/routes/publicChatRoutes.js'; // Public chat routes for the widget
 import internalRoutes from './src/routes/internalRoutes.js'; // Internal routes for scheduled tasks etc.
+import authRoutes from './src/routes/authRoutes.js';
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -125,6 +126,10 @@ logger.info('>>> server.js: Routes /api/public-chat mounted');
 logger.debug('>>> server.js: Mounting routes /api/internal/v1');
 app.use('/api/internal/v1', internalRoutes); // Using versioned path
 logger.info('>>> server.js: Routes /api/internal/v1 mounted');
+
+logger.debug('>>> server.js: Mounting routes /api/auth');
+app.use('/api/auth', authRoutes);
+logger.info('>>> server.js: Routes /api/auth mounted');
 
 
 // --- Manejo de Errores (Al final) ---

--- a/synchat-ai-backend/src/controllers/authController.js
+++ b/synchat-ai-backend/src/controllers/authController.js
@@ -1,0 +1,64 @@
+// synchat-ai-backend/src/controllers/authController.js
+import { supabase } from '../services/supabaseClient.js'; // Backend Supabase client (service role)
+import logger from '../utils/logger.js'; // Assuming logger is in utils
+
+const UUID_REGEX = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export async function handlePostRegistration(req, res) {
+    const { userId, userEmail } = req.body;
+
+    if (!userId || !userEmail) {
+        logger.warn('handlePostRegistration: Missing userId or userEmail.');
+        return res.status(400).json({ message: 'User ID and User Email are required.' });
+    }
+    if (!UUID_REGEX.test(userId)) {
+        logger.warn(`handlePostRegistration: Invalid userId format: ${userId}`);
+        return res.status(400).json({ message: 'Invalid User ID format.' });
+    }
+    if (!EMAIL_REGEX.test(userEmail)) {
+        logger.warn(`handlePostRegistration: Invalid userEmail format: ${userEmail}`);
+        return res.status(400).json({ message: 'Invalid User Email format.' });
+    }
+
+    try {
+        logger.info(`handlePostRegistration: Received request for userId: ${userId}, userEmail: ${userEmail}`);
+
+        const { data: existingClient, error: checkError } = await supabase
+            .from('synchat_clients')
+            .select('client_id')
+            .eq('client_id', userId)
+            .maybeSingle(); // Use maybeSingle to not error if not found
+
+        if (checkError) {
+            logger.error(`handlePostRegistration: Error checking existing synchat_client for ${userId}:`, checkError.message);
+            return res.status(500).json({ message: 'Database error while checking client existence.' });
+        }
+
+        if (existingClient) {
+            logger.info(`handlePostRegistration: Client entry already exists for ${userId}. Skipping creation.`);
+            return res.status(200).json({ message: 'Client entry already exists and is confirmed.', clientId: userId });
+        }
+
+        logger.info(`handlePostRegistration: Calling RPC public.create_synchat_client_entry for user ${userId}`);
+        const { error: rpcError } = await supabase.rpc('create_synchat_client_entry', {
+            p_client_id: userId,
+            p_email: userEmail
+        });
+
+        if (rpcError) {
+            logger.error(`handlePostRegistration: Error calling RPC create_synchat_client_entry for ${userId}:`, rpcError);
+            // Check for specific Supabase error details if possible
+            if (rpcError.details) logger.error(`RPC Error Details: ${rpcError.details}`);
+            if (rpcError.hint) logger.error(`RPC Error Hint: ${rpcError.hint}`);
+            return res.status(500).json({ message: 'Failed to create client entry due to a database procedure error.' });
+        }
+
+        logger.info(`handlePostRegistration: Successfully ensured synchat_client entry for ${userId}`);
+        return res.status(201).json({ message: 'Client initialized successfully.', clientId: userId });
+
+    } catch (error) {
+        logger.error('handlePostRegistration: Unhandled exception:', error);
+        return res.status(500).json({ message: 'Internal server error during post-registration processing.' });
+    }
+}

--- a/synchat-ai-backend/src/routes/authRoutes.js
+++ b/synchat-ai-backend/src/routes/authRoutes.js
@@ -1,0 +1,15 @@
+// synchat-ai-backend/src/routes/authRoutes.js
+import express from 'express';
+import { handlePostRegistration } from '../controllers/authController.js'; // Adjust path as needed
+
+const router = express.Router();
+
+// If not using user's token for this specific call, consider an API key middleware
+// For Option 3a (passing userId, userEmail in body):
+router.post('/post-registration', handlePostRegistration);
+
+// For Option 3b (using user's token to get userId, userEmail):
+// router.post('/post-registration', protectRoute, handlePostRegistrationWithToken);
+// where handlePostRegistrationWithToken would get userId/email from req.user
+
+export default router;

--- a/synchat-ai-backend/supabase/migrations_v1_master/20230101001900_19_create_remaining_triggers.sql
+++ b/synchat-ai-backend/supabase/migrations_v1_master/20230101001900_19_create_remaining_triggers.sql
@@ -23,15 +23,15 @@ $$;
 COMMENT ON FUNCTION public.handle_new_user_to_synchat_client() IS 'Handles the creation of a new entry in public.synchat_clients when a new user signs up in auth.users.';
 
 -- Drop trigger if it exists from a previous partial run, then create.
-DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
-CREATE TRIGGER on_auth_user_created
-  AFTER INSERT ON auth.users
-  FOR EACH ROW
-  EXECUTE FUNCTION public.handle_new_user_to_synchat_client();
+-- DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+-- CREATE TRIGGER on_auth_user_created
+--   AFTER INSERT ON auth.users
+--   FOR EACH ROW
+--   EXECUTE FUNCTION public.handle_new_user_to_synchat_client();
 
-COMMENT ON TRIGGER on_auth_user_created ON auth.users IS 'When a new user is created in auth.users, this trigger automatically creates a corresponding client entry in public.synchat_clients.';
+-- COMMENT ON TRIGGER on_auth_user_created ON auth.users IS 'When a new user is created in auth.users, this trigger automatically creates a corresponding client entry in public.synchat_clients.';
 
-RAISE NOTICE 'Trigger on_auth_user_created on auth.users and function handle_new_user_to_synchat_client created.';
+-- RAISE NOTICE 'Trigger on_auth_user_created on auth.users and function handle_new_user_to_synchat_client created.';
 
 -- 2. Function and Trigger to update conversation_last_message_at on new message
 CREATE OR REPLACE FUNCTION public.update_conversation_last_message_at()

--- a/synchat-ai-backend/supabase/migrations_v1_master/20250604011303_create_client_entry_function.sql
+++ b/synchat-ai-backend/supabase/migrations_v1_master/20250604011303_create_client_entry_function.sql
@@ -1,0 +1,24 @@
+-- supabase/migrations_v1_master/20250604011303_create_client_entry_function.sql
+CREATE OR REPLACE FUNCTION public.create_synchat_client_entry(
+    p_client_id UUID,
+    p_email TEXT
+)
+RETURNS VOID -- Or BOOLEAN, or the client_id, depending on desired feedback
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  INSERT INTO public.synchat_clients (client_id, email, client_name, created_at, updated_at)
+  VALUES (
+    p_client_id,
+    p_email,
+    COALESCE(split_part(p_email, '@', 1), 'New User ' || p_client_id::text),
+    NOW(),
+    NOW()
+  )
+  ON CONFLICT (client_id) DO NOTHING;
+END;
+$$;
+
+COMMENT ON FUNCTION public.create_synchat_client_entry(UUID, TEXT)
+IS 'Creates an entry in public.synchat_clients for a new user. Called explicitly by the backend.';


### PR DESCRIPTION
This commit refactors the creation of entries in `public.synchat_clients` after user registration. The previous mechanism used a Supabase trigger on `auth.users`, which faced permission issues.

The new approach involves:
1.  A new SQL function `public.create_synchat_client_entry(UUID, TEXT)` with `SECURITY DEFINER` to handle the insertion into `public.synchat_clients`.
2.  The old `on_auth_user_created` trigger on `auth.users` has been commented out from the migrations.
3.  A new backend API endpoint `POST /api/auth/post-registration` has been created in `synchat-ai-backend`.
    - This endpoint accepts `userId` and `userEmail`.
    - It checks if a client already exists.
    - If not, it calls the `create_synchat_client_entry` SQL function.
4.  The frontend's `handleSignUp` function in `mi-bot-atencion/src/auth.js` has been updated to call this new backend endpoint after a successful Supabase `auth.signUp()`.

This change centralizes client creation logic in the backend application, providing more robust error handling and control over the process, and resolves the permission issues associated with the auth trigger.