### PR TITLE
Fix: Resolve multiple issues related to chat functionality

### DIFF
--- a/synchat-ai-backend/supabase/migrations_v1_master/20230101001300_13_create_ia_resolutions_log_table.sql
+++ b/synchat-ai-backend/supabase/migrations_v1_master/20230101001300_13_create_ia_resolutions_log_table.sql
@@ -20,12 +20,12 @@ COMMENT ON COLUMN public.ia_resolutions_log.details IS 'JSONB field to store add
 
 -- Indexes
 CREATE INDEX IF NOT EXISTS idx_ia_resolutions_log_client_id ON public.ia_resolutions_log(client_id);
-CREATE INDEX IF NOT EXISTS idx_ia_resolutions_log_conversation_id ON public.ia_resolutions_log(conversation_id WHERE conversation_id IS NOT NULL);
+CREATE INDEX IF NOT EXISTS idx_ia_resolutions_log_conversation_id ON public.ia_resolutions_log(conversation_id) WHERE conversation_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_ia_resolutions_log_resolved_at ON public.ia_resolutions_log(resolved_at DESC);
 CREATE INDEX IF NOT EXISTS idx_ia_resolutions_log_billing_cycle_id ON public.ia_resolutions_log(billing_cycle_id);
 CREATE INDEX IF NOT EXISTS idx_ia_resolutions_log_details_gin ON public.ia_resolutions_log USING GIN (details) WHERE details IS NOT NULL;
 
-RAISE NOTICE 'Table public.ia_resolutions_log created with comments and indexes.';
+-- RAISE NOTICE 'Table public.ia_resolutions_log created with comments and indexes.';
 
 -- RLS: By default, this table might be sensitive. Add policies as needed.
 -- For now, enabling RLS and a restrictive default will be handled later or assumed service_role access.


### PR DESCRIPTION
This commit addresses several issues:
1.  Resolves original error `column synchat_clients.billing_cycle_id does not exist`:
    - Adds `billing_cycle_id` column to `synchat_clients` table via a new migration.
    - Ensures `getClientConfig` in `databaseService.js` selects this column.

2.  Corrects and restores `billing_cycle_id` functionality for `ia_resolutions_log`:
    - Restores `billing_cycle_id` column to `ia_resolutions_log` table schema in relevant migration files.
    - Restores logic in `clientDashboardController.js` to use `billing_cycle_id` for filtering usage resolutions.

3.  Fixes migration file syntax errors:
    - Corrects `CREATE INDEX` syntax in `migrations_v1_master/20230101001300_13_create_ia_resolutions_log_table.sql`.
    - Comments out a `RAISE NOTICE` statement in the same file that was causing parsing issues. These fixes allow pending migrations to run correctly.

4.  Implements missing `createConversation` function:
    - Provides the implementation for `createConversation` in `databaseService.js`, resolving the "Failed to create conversation or retrieve its ID" error. The function now correctly inserts a new conversation record and returns its ID.

These changes should ensure proper database schema setup through migrations and resolve critical runtime errors in the chat functionality.