### PR TITLE
Debug: Add hyper-defensive returns and detailed logging for chat error

### DIFF
--- a/synchat-ai-backend/src/controllers/chatController.js
+++ b/synchat-ai-backend/src/controllers/chatController.js
@@ -447,6 +447,34 @@ export const handleChatMessage = async (req, res, next) => {
             const messagesForAPI_for_log = typeof messagesForAPI !== 'undefined' ? messagesForAPI : [{role:"system", content:"Error: messagesForAPI not constructed"}, {role:"user", content: effectiveQuery || ""}];
             const botReplyText_for_log = typeof botReplyText !== 'undefined' ? botReplyText : "Error: Reply not generated";
 
+            // ---- START DEBUG LOGGING ----
+            logger.debug('(ChatCtrl) Pre-map Debugging:');
+            logger.debug(`(ChatCtrl) typeof hybridSearchOutput: ${typeof hybridSearchOutput}`);
+            if (hybridSearchOutput && typeof hybridSearchOutput === 'object') {
+                logger.debug(`(ChatCtrl) hybridSearchOutput.results exists: ${hybridSearchOutput.hasOwnProperty('results')}, isArray: ${Array.isArray(hybridSearchOutput.results)}`);
+                if (hybridSearchOutput.hasOwnProperty('results')) {
+                    logger.debug(`(ChatCtrl) hybridSearchOutput.results (first few): ${JSON.stringify(hybridSearchOutput.results?.slice(0,2))}`);
+                }
+                logger.debug(`(ChatCtrl) hybridSearchOutput.pipelineDetails exists: ${hybridSearchOutput.hasOwnProperty('pipelineDetails')}`);
+                if (hybridSearchOutput.pipelineDetails && typeof hybridSearchOutput.pipelineDetails === 'object') {
+                    logger.debug(`(ChatCtrl) hybridSearchOutput.pipelineDetails.finalRankedResultsForPlayground exists: ${hybridSearchOutput.pipelineDetails.hasOwnProperty('finalRankedResultsForPlayground')}, isArray: ${Array.isArray(hybridSearchOutput.pipelineDetails.finalRankedResultsForPlayground)}`);
+                    if (hybridSearchOutput.pipelineDetails.hasOwnProperty('finalRankedResultsForPlayground')) {
+                         logger.debug(`(ChatCtrl) hybridSearchOutput.pipelineDetails.finalRankedResultsForPlayground (first few): ${JSON.stringify(hybridSearchOutput.pipelineDetails.finalRankedResultsForPlayground?.slice(0,2))}`);
+                    }
+                } else {
+                    logger.debug("(ChatCtrl) hybridSearchOutput.pipelineDetails is null or not an object.");
+                }
+            } else {
+                logger.debug("(ChatCtrl) hybridSearchOutput is null, undefined, or not an object.");
+            }
+
+            logger.debug(`(ChatCtrl) resultsToMap (derived from hybridSearchOutput.results): isArray: ${Array.isArray(resultsToMap)}, length: ${resultsToMap?.length}`);
+            logger.debug(`(ChatCtrl) resultsToMap (first few): ${JSON.stringify(resultsToMap?.slice(0,2))}`);
+
+            logger.debug(`(ChatCtrl) rawRankedResultsForLog (derived): isArray: ${Array.isArray(rawRankedResultsForLog)}, length: ${rawRankedResultsForLog?.length}`);
+            logger.debug(`(ChatCtrl) rawRankedResultsForLog (first few): ${JSON.stringify(rawRankedResultsForLog?.slice(0,2))}`);
+            // ---- END DEBUG LOGGING ----
+
             const retrievedContextForLog = (Array.isArray(rawRankedResultsForLog) ? rawRankedResultsForLog : []).map(c => ({
                 id: c.id,
                 content_preview: (typeof c.content === 'string' ? c.content.substring(0,150) : "") + "...", // Safe substring


### PR DESCRIPTION
This commit introduces further measures to diagnose and prevent the persistent 'Cannot read properties of undefined (reading map)' error in `chatController.js`.

1.  **Hyper-Defensive Return in `hybridSearch` (`databaseService.js`):**
    - The return path for when "No results after merging" occurs has been meticulously updated. It now guarantees that the returned object contains `results: []` and, if `returnPipelineDetails` is true, `pipelineDetails.finalRankedResultsForPlayground: []` (among other safely defaulted fields like `propositionResults`, `searchParams`, etc.).
    - Added a `logger.debug` statement to log the exact JSON structure of the object being returned in this specific "no results" path to aid in verifying its correctness during execution.

2.  **Explicit Logging in `chatController.js` (`handleChatMessage`):**
    - Before the line where `retrievedContextForLog` is created (which was the site of the `.map()` error), detailed `logger.debug` statements have been added.
    - These logs will output the type and content (or key properties) of `hybridSearchOutput`, the derived `resultsToMap`, and the `rawRankedResultsForLog` variables.
    - This will provide a clear snapshot of the data from the controller's perspective immediately before the operation that was failing.

These changes aim to either definitively resolve the error by ensuring correct data structures are passed, or provide highly detailed logs to pinpoint any remaining discrepancy if the error persists.

This commit is cumulative and includes all prior fixes from this session.