### PR TITLE
Here's the proposed fix:

### DIFF
--- a/synchat-ai-backend/src/controllers/chatController.js
+++ b/synchat-ai-backend/src/controllers/chatController.js
@@ -129,7 +129,11 @@ export const handleChatMessage = async (req, res, next) => {
         }
         logger.debug("(ChatCtrl) No encontrado en caché. Procesando...");
 
-        const conversationHistory = await db.getConversationHistory(conversationId);
+        let conversationHistory = await db.getConversationHistory(conversationId);
+        if (!Array.isArray(conversationHistory)) {
+            logger.warn(`(ChatCtrl) conversationHistory for CV:${conversationId} was not an array, defaulting to empty. Original value:`, conversationHistory);
+            conversationHistory = []; // Ensure it's an array
+        }
         const hybridSearchOutput = await db.hybridSearch(
             effectiveClientId,
             effectiveQuery,


### PR DESCRIPTION
- I've added a check to ensure `conversationHistory` is an array before calling `.map()` on it. This will prevent a potential TypeError if `db.getConversationHistory` were to return a non-array value.
- The controller already appeared to have robust checks for the primary suspect of a similar past error (mapping of `hybridSearchOutput.results`), and this change adds further resilience.