### PR TITLE
Revert: Revert 'CORS Hardening' changes to resolve Vercel deployment …

### DIFF
--- a/synchat-ai-backend/server.js
+++ b/synchat-ai-backend/server.js
@@ -1,5 +1,4 @@
 // synchat-ai-backend/server.js
-console.log('[server.js] Running version 2024-06-06-A -- CORS Hardening');
 import 'dotenv/config'; // Loads .env from CWD (expected to be /app)
 
 // NOTE: All other imports that might depend on process.env should come AFTER the line above.
@@ -59,41 +58,41 @@ const corsOptionsDelegate = function (req, callback) {
     let corsOptions;
     const origin = req.header('Origin');
 
-    // New explicit check for widget + frontendAppURL
-    if (req.path.startsWith('/api/public-chat') && origin === frontendAppURL) {
-        corsOptions = {
-            origin: true, // Allow this specific origin
-            credentials: true,
-            methods: 'GET,POST,PUT,DELETE,OPTIONS',
-            allowedHeaders: 'Content-Type,Authorization,X-Requested-With,X-CSRF-Token,Device-ID,Auth-Token, Supabase-Auth-Token'
-        };
-        logger.info(`CORS check PASSED (Explicit /api/public-chat from frontendAppURL) for origin: ${origin} (Path: ${req.path})`);
-    } else {
-        // Existing logic
-        const isHealthCheck = req.path === '/';
-        const isFrontendApp = origin && frontendAppURL && origin === frontendAppURL;
-        let isWidgetAllowed = false;
-        if (req.path.startsWith('/api/public-chat')) {
-            if (allowAllForWidget) {
-                isWidgetAllowed = true;
-            } else if (origin && widgetOriginsList.includes(origin)) {
-                isWidgetAllowed = true;
-            }
-        }
-        const isPostRegistration = req.path === '/api/auth/post-registration' && req.method === 'POST';
+    // Determinar si la petición es para la ruta raíz (health check)
+    const isHealthCheck = req.path === '/';
 
-        if (isFrontendApp || isWidgetAllowed || isHealthCheck || isPostRegistration) {
-            corsOptions = {
-                origin: true,
-                credentials: true,
-                methods: 'GET,POST,PUT,DELETE,OPTIONS',
-                allowedHeaders: 'Content-Type,Authorization,X-Requested-With,X-CSRF-Token,Device-ID,Auth-Token, Supabase-Auth-Token'
-            };
-            // Optional: logger.info(`CORS check PASSED (General) for origin: ${origin || 'Not specified'} (Path: ${req.path})`);
-        } else {
-            corsOptions = { origin: false };
-            logger.warn(`CORS check FAILED for origin: ${origin || 'Not specified'} (Path: ${req.path})`);
+    // Determinar si el origen es la aplicación frontend principal
+    const isFrontendApp = origin && frontendAppURL && origin === frontendAppURL;
+
+    // Determinar si el origen está permitido para el widget
+    // Si allowAllForWidget es true, cualquier origen es permitido para rutas del widget.
+    // Si no, se verifica contra widgetOriginsList.
+    // Esto aplica específicamente a rutas que comienzan con /api/public-chat (rutas del widget)
+    let isWidgetAllowed = false;
+    if (req.path.startsWith('/api/public-chat')) {
+        if (allowAllForWidget) {
+            isWidgetAllowed = true;
+        } else if (origin && widgetOriginsList.includes(origin)) {
+            isWidgetAllowed = true;
         }
+    }
+
+    // Permite específicamente la ruta /api/auth/post-registration desde cualquier origen
+    // Esto es para manejar el caso donde el redirect desde el proveedor de auth (ej. Google)
+    // no tiene un Origin header o es null, o para simplificar la configuración inicial.
+    const isPostRegistration = req.path === '/api/auth/post-registration' && req.method === 'POST';
+
+    if (isFrontendApp || isWidgetAllowed || isHealthCheck || isPostRegistration) {
+        corsOptions = {
+            origin: true,
+            credentials: true,
+            methods: 'GET,POST,PUT,DELETE,OPTIONS', // Asegúrate que OPTIONS está aquí
+            allowedHeaders: 'Content-Type,Authorization,X-Requested-With,X-CSRF-Token,Device-ID,Auth-Token, Supabase-Auth-Token' // Cabeceras personalizadas
+        };
+        // logger.info(`CORS check PASSED for origin: ${origin || 'Not specified'} (Path: ${req.path})`);
+    } else {
+        corsOptions = { origin: false }; // Rechazar otros orígenes
+        logger.warn(`CORS check FAILED for origin: ${origin || 'Not specified'} (Path: ${req.path})`);
     }
     callback(null, corsOptions);
 };


### PR DESCRIPTION
…issue

This commit reverts the changes made in commit `fix/cors-hardening-20240606`. The 'CORS Hardening' changes, while intended to make CORS handling more robust, are suspected to have caused a Vercel deployment failure.

The specific changes reverted are:
- Removal of the top-level console.log statement for versioning.
- Restoration of the `corsOptionsDelegate` function to its state prior to the addition of an explicit if/else block for public chat paths from the frontendAppURL.

The `server.js` file is now in the state it was after the first set of CORS fixes (where `frontendAppURL` was ensured to be in `widgetOriginsList`), which is commit `fix/cors-widget-origin`.

This reversion is an attempt to allow Vercel to deploy `server.js` successfully. If deployment succeeds, further investigation may be needed if the original CORS issue resurfaces with this version.