### PR TITLE
Fix: Ensure CORS headers on 500 errors from chatController

### DIFF
--- a/synchat-ai-backend/src/controllers/chatController.js
+++ b/synchat-ai-backend/src/controllers/chatController.js
@@ -418,7 +418,18 @@ export const handleChatMessage = async (req, res, next) => {
         }
     } catch (error) {
         logger.error(`(ChatCtrl) Error general en handleChatMessage para ${conversationId}:`, error.message, error.stack?.substring(0,500));
-        next(error);
+        // It's good practice to check if headers have already been sent,
+        // though in this specific flow (error during main processing), it's less likely.
+        if (res.headersSent) {
+            // If headers were already sent, we must delegate to the default Express error handler.
+            // Calling next(error) is appropriate here.
+            return next(error);
+        }
+        res.status(500).json({
+            reply: 'Lo siento, ocurrió un error inesperado al procesar tu mensaje. Por favor, inténtalo de nuevo más tarde.',
+            // Optionally, include a reference or more details if appropriate for client/debugging
+            // error_detail: error.message // Be cautious about exposing raw error messages
+        });
     }
 };
 


### PR DESCRIPTION
Previously, when an error occurred within the main try...catch block of `handleChatMessage` in `chatController.js`, `next(error)` was called. This passed the error to the global error handler in `server.js`, which would send a 500 JSON response. However, this global error handler's response did not include the necessary CORS headers, leading your browser to report a CORS violation instead of just the 500 server error.

This commit modifies the `catch` block in `handleChatMessage`:
- Instead of calling `next(error)`, it now directly sends a `res.status(500).json(...)` response with a user-friendly message, provided headers have not already been sent.

By sending the error response directly from the `handleChatMessage` function, it's expected that the main `cors` middleware (which would have already processed and approved the origin for the incoming request) will correctly apply the `Access-Control-Allow-Origin` and other relevant CORS headers to this error response.

This should prevent your client from incorrectly perceiving a server-side error as a CORS policy violation.