### PR TITLE
Fix: Ensure CORS headers on centrally handled error responses

### DIFF
--- a/synchat-ai-backend/src/controllers/chatController.js
+++ b/synchat-ai-backend/src/controllers/chatController.js
@@ -418,18 +418,7 @@ export const handleChatMessage = async (req, res, next) => {
         }
     } catch (error) {
         logger.error(`(ChatCtrl) Error general en handleChatMessage para ${conversationId}:`, error.message, error.stack?.substring(0,500));
-        // It's good practice to check if headers have already been sent,
-        // though in this specific flow (error during main processing), it's less likely.
-        if (res.headersSent) {
-            // If headers were already sent, we must delegate to the default Express error handler.
-            // Calling next(error) is appropriate here.
-            return next(error);
-        }
-        res.status(500).json({
-            reply: 'Lo siento, ocurrió un error inesperado al procesar tu mensaje. Por favor, inténtalo de nuevo más tarde.',
-            // Optionally, include a reference or more details if appropriate for client/debugging
-            // error_detail: error.message // Be cautious about exposing raw error messages
-        });
+        next(error);
     }
 };
 


### PR DESCRIPTION
This commit addresses the issue where server-generated error responses (e.g., 500 Internal Server Error) were missing CORS headers, causing your client browsers to report CORS violations instead of the actual server error.

The following changes were implemented:

1.  In `synchat-ai-backend/src/controllers/chatController.js`:
    - The `catch` block in the `handleChatMessage` function has been reverted to call `next(error)`. This delegates error handling to the global error middleware, which is now enhanced.

2.  In `synchat-ai-backend/server.js`:
    - The `corsOptionsDelegate` function has been modified to set a flag `req.isCorsApproved = true` on the request object if the CORS check passes for the origin, and `false` otherwise.
    - The global error handling middleware (`app.use((err, req, res, next) => ...`) has been updated. It now checks if `req.isCorsApproved === true` and if an `Origin` header is present. If both are true, it manually sets the `Access-Control-Allow-Origin`, `Access-Control-Allow-Credentials`, and `Vary: Origin` headers on the error response before sending it.

This ensures that if a request's origin is initially approved by the CORS policy, any subsequent server error response handled by the global error middleware will include the necessary CORS headers. This allows your client to correctly receive and process server error details without them being blocked as CORS violations.