### PR TITLE
fix: Use last_message_at for conversation timestamp updates

### DIFF
--- a/synchat-ai-backend/src/services/databaseService.js
+++ b/synchat-ai-backend/src/services/databaseService.js
@@ -1733,7 +1733,7 @@ export const logResolution = async (conversationId, resolutionType) => {
         const updated_at = new Date().toISOString();
         const { error: updateConvError } = await supabase
             .from('conversations')
-            .update({ status: 'resolved', updated_at })
+            .update({ status: 'resolved', last_message_at: new Date().toISOString() })
             .eq('conversation_id', conversationId);
 
         if (updateConvError) {
@@ -1781,7 +1781,7 @@ export const requestHumanHandover = async (conversationId) => {
         const updated_at = new Date().toISOString();
         const { error } = await supabase
             .from('conversations')
-            .update({ status: 'pending', updated_at })
+            .update({ status: 'pending', last_message_at: new Date().toISOString() })
             .eq('conversation_id', conversationId);
 
         if (error) {


### PR DESCRIPTION
Corrects a runtime error in databaseService.js caused by attempting to update a non-existent column 'updated_at' in the 'conversations' table.

The 'conversations' table uses 'last_message_at' to track activity timestamps. This commit updates the following functions to use the correct column name:

- In `logResolution`: Changed `updated_at` to `last_message_at` when setting conversation status to 'resolved'.
- In `requestHumanHandover`: Changed `updated_at` to `last_message_at` when setting conversation status to 'pending'.

This change aligns the data access logic with the existing database schema, resolving the "Could not find the 'updated_at' column" error.